### PR TITLE
Add site.OutboundVnetRouting.ManagedIdentityTraffic flag to 2025-05-0…

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/CommonDefinitions.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/CommonDefinitions.json
@@ -4277,6 +4277,10 @@
         "backupRestoreTraffic": {
           "description": "Enables Backup and Restore operations over virtual network. Previously called VnetBackupRestoreEnabled",
           "type": "boolean"
+        },
+        "managedIdentityTraffic": {
+          "description": "Enables Managed Identity operations over virtual network.",
+          "type": "boolean"
         }
       }
     },

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CloneWebApp.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CloneWebApp.json
@@ -68,7 +68,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -185,7 +186,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CloneWebAppSlot.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CloneWebAppSlot.json
@@ -69,7 +69,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -186,7 +187,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateFunctionAppFlexConsumption.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateFunctionAppFlexConsumption.json
@@ -86,7 +86,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -233,7 +234,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateFunctionAppFlexConsumptionWithDetails.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateFunctionAppFlexConsumptionWithDetails.json
@@ -97,7 +97,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -253,7 +254,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateWebApp.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateWebApp.json
@@ -56,7 +56,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -179,7 +180,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateWebAppSlot.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/CreateOrUpdateWebAppSlot.json
@@ -57,7 +57,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -174,7 +175,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/GetWebApp.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/GetWebApp.json
@@ -49,7 +49,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/GetWebAppSlot.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/GetWebAppSlot.json
@@ -50,7 +50,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/ListWebAppSlots.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/ListWebAppSlots.json
@@ -51,7 +51,8 @@
                 "applicationTraffic": false,
                 "contentShareTraffic": false,
                 "imagePullTraffic": false,
-                "backupRestoreTraffic": false
+                "backupRestoreTraffic": false,
+                "managedIdentityTraffic": false
               },
               "siteConfig": {
                 "numberOfWorkers": 1,
@@ -163,7 +164,8 @@
                 "applicationTraffic": false,
                 "contentShareTraffic": false,
                 "imagePullTraffic": false,
-                "backupRestoreTraffic": false
+                "backupRestoreTraffic": false,
+                "managedIdentityTraffic": false
               },
               "siteConfig": {
                 "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/ListWebApps.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/ListWebApps.json
@@ -49,7 +49,8 @@
                 "applicationTraffic": false,
                 "contentShareTraffic": false,
                 "imagePullTraffic": false,
-                "backupRestoreTraffic": false
+                "backupRestoreTraffic": false,
+                "managedIdentityTraffic": false
               },
               "siteConfig": {
                 "numberOfWorkers": 1,
@@ -166,7 +167,8 @@
                 "applicationTraffic": false,
                 "contentShareTraffic": false,
                 "imagePullTraffic": false,
-                "backupRestoreTraffic": false
+                "backupRestoreTraffic": false,
+                "managedIdentityTraffic": false
               },
               "siteConfig": {
                 "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/ListWebAppsByResourceGroup.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/ListWebAppsByResourceGroup.json
@@ -50,7 +50,8 @@
                 "applicationTraffic": false,
                 "contentShareTraffic": false,
                 "imagePullTraffic": false,
-                "backupRestoreTraffic": false
+                "backupRestoreTraffic": false,
+                "managedIdentityTraffic": false
               },
               "siteConfig": {
                 "numberOfWorkers": 1,
@@ -167,7 +168,8 @@
                 "applicationTraffic": false,
                 "contentShareTraffic": false,
                 "imagePullTraffic": false,
-                "backupRestoreTraffic": false
+                "backupRestoreTraffic": false,
+                "managedIdentityTraffic": false
               },
               "siteConfig": {
                 "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/UpdateWebApp.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/UpdateWebApp.json
@@ -54,7 +54,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -176,7 +177,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,

--- a/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/UpdateWebAppSlot.json
+++ b/specification/web/resource-manager/Microsoft.Web/stable/2024-11-01/examples/UpdateWebAppSlot.json
@@ -55,7 +55,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,
@@ -172,7 +173,8 @@
             "applicationTraffic": false,
             "contentShareTraffic": false,
             "imagePullTraffic": false,
-            "backupRestoreTraffic": false
+            "backupRestoreTraffic": false,
+            "managedIdentityTraffic": false
           },
           "siteConfig": {
             "numberOfWorkers": 1,


### PR DESCRIPTION
Add existing OutboundVnetRouting.ManagedIdentityTraffic flag to API spec for 2025-05-01 API for Microsoft.web/sites resource.

This property has been deployed with ANT104 Geo build: https://dev.azure.com/msazure/One/_git/AAPT-Antares-Websites?path=/src/Hosting/AdministrationService/Microsoft.Web.Hosting.Administration.Api/WebEntities/OutboundVnetRouting.cs&version=GBrelease/ANT104-GeoRel&line=44&lineEnd=48&lineStartColumn=1&lineEndColumn=58&lineStyle=plain&_a=contents

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
